### PR TITLE
feat: controller moodbased routing

### DIFF
--- a/src/modules/contents/contents.controller.ts
+++ b/src/modules/contents/contents.controller.ts
@@ -1,4 +1,21 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Query, ValidationPipe } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { ContentsService } from './contents.service';
+import { GetContentQueryDto } from './dto/get-content-query.dto';
+import { ContentEntity } from './model/content.entity';
+import { GetContentDoc } from './docs/get-content.doc';
 
+@ApiTags('contents')
 @Controller('contents')
-export class ContentsController {}
+export class ContentsController {
+  constructor(private readonly contentsService: ContentsService) {}
+
+  @Get()
+  @GetContentDoc()
+  async getContentByMood(
+    @Query(new ValidationPipe({ transform: true }))
+    query: GetContentQueryDto,
+  ): Promise<ContentEntity[]> {
+    return this.contentsService.getContentsByMood(query.mood, query.type);
+  }
+}

--- a/src/modules/contents/docs/get-content.doc.ts
+++ b/src/modules/contents/docs/get-content.doc.ts
@@ -1,0 +1,45 @@
+import { ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
+import { ContentEntity } from '../model/content.entity';
+import { ContentType } from '../enum/content.enum';
+
+export const GetContentDoc = () => {
+  return function (
+    target: any,
+    propertyKey: string,
+    descriptor: PropertyDescriptor,
+  ) {
+    ApiOperation({
+      summary: 'Get content by mood and type',
+      description:
+        'Retrieves a list of content items based on the specified mood and content type',
+    })(target, propertyKey, descriptor);
+
+    ApiQuery({
+      name: 'mood',
+      description: 'The mood to search content for',
+      example: 'sad',
+      required: true,
+    })(target, propertyKey, descriptor);
+
+    ApiQuery({
+      name: 'type',
+      description: 'The type of content to retrieve',
+      enum: ContentType,
+      example: ContentType.MOVIE,
+      required: true,
+    })(target, propertyKey, descriptor);
+
+    ApiResponse({
+      status: 200,
+      description: 'Returns a list of content matching the mood and type',
+      type: [ContentEntity],
+    })(target, propertyKey, descriptor);
+
+    ApiResponse({
+      status: 400,
+      description: 'Bad Request - Invalid query parameters',
+    })(target, propertyKey, descriptor);
+
+    return descriptor;
+  };
+};

--- a/src/modules/contents/dto/content.dto.ts
+++ b/src/modules/contents/dto/content.dto.ts
@@ -1,6 +1,0 @@
-import { ContentType } from '@modules/contents/enum/content.enum';
-
-export class GetContentDto {
-  mood: string;
-  type: ContentType;
-}

--- a/src/modules/contents/dto/get-content-query.dto.ts
+++ b/src/modules/contents/dto/get-content-query.dto.ts
@@ -1,0 +1,12 @@
+import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import { ContentType } from '../enum/content.enum';
+
+export class GetContentQueryDto {
+  @IsString()
+  @IsNotEmpty()
+  mood: string;
+
+  @IsEnum(ContentType)
+  @IsNotEmpty()
+  type: ContentType;
+}


### PR DESCRIPTION
# Pull Request

## Description

Implemented a new GET endpoint that retrieves content based on mood and content type, serving as the public API interface for mood-based content retrieval.

## Related Issue

Fixes #4 

## Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation updates
- [ ] style: Code style/formatting changes
- [ ] refactor: Code refactoring
- [ ] perf: Performance improvements
- [ ] test: Test additions/updates
- [ ] chore: Build process or tooling changes
- [ ] ci: CI configuration changes
- [ ] other: <!-- describe -->

## How Has This Been Tested?


- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests

## Test Evidence
![nii](https://github.com/user-attachments/assets/98fcf7d6-b66b-4833-981c-fb06e02ef5ee)

## Documentation Screenshots (if applicable)
![content-doc](https://github.com/user-attachments/assets/ff9dbd5e-142f-471e-8da0-9383efae6be3)
![content-docs](https://github.com/user-attachments/assets/ecd2866d-6497-41ee-949f-dfcbbec4b136)

## Checklist

- [x] My code follows the project's coding style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have included a screenshot showing all tests passing
- [x] I have included documentation screenshots (if applicable)

## Additional Notes
### Performance Considerations
- No database queries in this implementation
- Content retrieval is delegated to respective provider services (Movies, Spotify, Books)
- Response time will depend on the underlying provider services