### PR TITLE
feat: add mood preferences for user customization

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { MoviesModule } from '@modules/contents/providers/movies/movies.module';
 import { HealthModule } from './health/health.module';
 import { AuthModule } from '@modules/auth/auth.module';
 import { UserModule } from '@modules/user/user.module';
+import { UserPreferencesModule } from '@modules/user-preferences/user-preferences.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AppConfigModule } from './config/config.module';
@@ -29,6 +30,7 @@ import { createDataSource } from './database/data-source';
     HealthModule,
     AuthModule,
     UserModule,
+    UserPreferencesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/database/migrations/1753203984798-AddMoodPreferencesToUserPreferences.ts
+++ b/src/database/migrations/1753203984798-AddMoodPreferencesToUserPreferences.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMoodPreferencesToUserPreferences1753203984798
+  implements MigrationInterface
+{
+  name = 'AddMoodPreferencesToUserPreferences1753203984798';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "user_preferences" 
+      ADD COLUMN "mood_preferences" JSON,
+      ADD COLUMN "mood_intensity_settings" JSON,
+      ADD COLUMN "custom_mood_categories" TEXT[],
+      ADD COLUMN "default_intensity_levels" INTEGER NOT NULL DEFAULT 5,
+      ADD COLUMN "enable_mood_intensity" BOOLEAN NOT NULL DEFAULT true,
+      ADD COLUMN "enable_custom_mood_categories" BOOLEAN NOT NULL DEFAULT true
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "user_preferences" 
+      DROP COLUMN "mood_preferences",
+      DROP COLUMN "mood_intensity_settings", 
+      DROP COLUMN "custom_mood_categories",
+      DROP COLUMN "default_intensity_levels",
+      DROP COLUMN "enable_mood_intensity",
+      DROP COLUMN "enable_custom_mood_categories"
+    `);
+  }
+}

--- a/src/modules/user-preferences/docs/mood-preferences.docs.ts
+++ b/src/modules/user-preferences/docs/mood-preferences.docs.ts
@@ -1,0 +1,461 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiBody,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
+
+export function GetMoodPreferencesDocs() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Get mood-specific preferences',
+      description:
+        'Retrieve mood-specific preferences for the authenticated user. If a mood is specified, returns preferences for that specific mood only.',
+    }),
+    ApiQuery({
+      name: 'mood',
+      required: false,
+      description: 'Specific mood to get preferences for',
+    }),
+    ApiResponse({
+      status: 200,
+      description: 'Mood preferences retrieved successfully',
+      schema: {
+        example: {
+          moodPreferences: {
+            happy: {
+              intensityLevels: [1, 2, 3, 4, 5],
+              preferredContentTypes: ['movie', 'music'],
+              customCategories: ['uplifting'],
+              defaultPreferences: {
+                contentTypes: ['comedy', 'pop'],
+                intensityThreshold: 3,
+              },
+            },
+          },
+          moodIntensitySettings: {
+            happy: {
+              minIntensity: 1,
+              maxIntensity: 5,
+              contentMappings: {
+                movie: { minIntensity: 1, maxIntensity: 5, priority: 1 },
+                music: { minIntensity: 1, maxIntensity: 5, priority: 2 },
+              },
+            },
+          },
+          customMoodCategories: ['uplifting', 'energetic'],
+          defaultIntensityLevels: 5,
+          enableMoodIntensity: true,
+          enableCustomMoodCategories: true,
+        },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized - Invalid or missing JWT token',
+      schema: {
+        example: {
+          statusCode: 401,
+          message: 'Unauthorized',
+          error: 'Unauthorized',
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'User preferences not found',
+      schema: {
+        example: {
+          statusCode: 404,
+          message: 'User preferences not found',
+          error: 'Not Found',
+        },
+      },
+    }),
+  );
+}
+
+export function UpdateMoodPreferencesDocs() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Update (upsert) mood-specific preferences',
+      description:
+        'Upsert mood-specific preferences for the authenticated user. If preferences for the given mood do not exist, they will be created; otherwise they will be updated. You can also update general mood settings without specifying a mood.',
+    }),
+    ApiBody({
+      description:
+        'Either provide a specific mood and its preferences, intensity settings, or provide general settings toggles.',
+      schema: {
+        oneOf: [
+          {
+            type: 'object',
+            required: ['mood', 'moodPreference'],
+            properties: {
+              mood: { type: 'string', example: 'happy' },
+              moodPreference: {
+                type: 'object',
+                properties: {
+                  intensityLevels: {
+                    type: 'array',
+                    items: { type: 'number' },
+                    example: [1, 2, 3, 4, 5],
+                  },
+                  preferredContentTypes: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    example: ['comedy', 'pop'],
+                  },
+                  customCategories: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    example: ['uplifting'],
+                  },
+                  defaultPreferences: {
+                    type: 'object',
+                    properties: {
+                      contentTypes: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        example: ['comedy', 'pop'],
+                      },
+                      intensityThreshold: { type: 'number', example: 3 },
+                    },
+                  },
+                },
+              },
+              intensitySettings: {
+                type: 'object',
+                properties: {
+                  minIntensity: { type: 'number', example: 1 },
+                  maxIntensity: { type: 'number', example: 5 },
+                  contentMappings: {
+                    type: 'object',
+                    additionalProperties: {
+                      type: 'object',
+                      properties: {
+                        minIntensity: { type: 'number', example: 1 },
+                        maxIntensity: { type: 'number', example: 5 },
+                        priority: { type: 'number', example: 1 },
+                      },
+                    },
+                    example: {
+                      comedy: { minIntensity: 1, maxIntensity: 5, priority: 1 },
+                      pop: { minIntensity: 1, maxIntensity: 5, priority: 2 },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          {
+            type: 'object',
+            properties: {
+              defaultIntensityLevels: { type: 'number', example: 10 },
+              enableMoodIntensity: { type: 'boolean', example: true },
+              enableCustomMoodCategories: { type: 'boolean', example: true },
+              customMoodCategories: {
+                type: 'array',
+                items: { type: 'string' },
+                example: ['energetic', 'calm', 'focused'],
+              },
+            },
+          },
+        ],
+      },
+    }),
+    ApiResponse({
+      status: 200,
+      description: 'Mood preferences updated successfully',
+      schema: {
+        example: {
+          id: 1,
+          theme: 'light',
+          notificationsEnabled: true,
+          preferredContentTypes: ['movie', 'music'],
+          moodPreferences: {
+            happy: {
+              intensityLevels: [1, 2, 3, 4, 5],
+              preferredContentTypes: ['comedy', 'pop'],
+              customCategories: ['uplifting'],
+              defaultPreferences: {
+                contentTypes: ['comedy', 'pop'],
+                intensityThreshold: 3,
+              },
+            },
+          },
+          moodIntensitySettings: {
+            happy: {
+              minIntensity: 1,
+              maxIntensity: 5,
+              contentMappings: {
+                comedy: { minIntensity: 1, maxIntensity: 5, priority: 1 },
+                pop: { minIntensity: 1, maxIntensity: 5, priority: 2 },
+              },
+            },
+          },
+          customMoodCategories: ['uplifting'],
+          defaultIntensityLevels: 5,
+          enableMoodIntensity: true,
+          enableCustomMoodCategories: true,
+        },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized - Invalid or missing JWT token',
+      schema: {
+        example: {
+          statusCode: 401,
+          message: 'Unauthorized',
+          error: 'Unauthorized',
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Invalid input data',
+      schema: {
+        example: {
+          statusCode: 400,
+          message: ['Invalid mood preference data'],
+          error: 'Bad Request',
+        },
+      },
+    }),
+  );
+}
+
+export function CreateCustomMoodCategoryDocs() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Create custom mood category',
+      description:
+        'Create a new custom mood category for the authenticated user',
+    }),
+    ApiBody({
+      schema: {
+        type: 'object',
+        required: ['categoryName'],
+        properties: {
+          categoryName: { type: 'string', example: 'energetic' },
+          description: { type: 'string', example: 'High energy moods' },
+          relatedMoods: {
+            type: 'array',
+            items: { type: 'string' },
+            example: ['happy', 'excited', 'motivated'],
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 201,
+      description: 'Custom mood category created successfully',
+      schema: {
+        example: {
+          id: 1,
+          customMoodCategories: ['uplifting', 'energetic', 'new-category'],
+        },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized - Invalid or missing JWT token',
+      schema: {
+        example: {
+          statusCode: 401,
+          message: 'Unauthorized',
+          error: 'Unauthorized',
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Category already exists or invalid input',
+      schema: {
+        example: {
+          statusCode: 400,
+          message: 'Mood category already exists',
+          error: 'Bad Request',
+        },
+      },
+    }),
+  );
+}
+
+export function DeleteCustomMoodCategoryDocs() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Delete custom mood category',
+      description: 'Delete a custom mood category for the authenticated user',
+    }),
+    ApiParam({
+      name: 'categoryName',
+      description: 'Name of the category to delete',
+    }),
+    ApiResponse({
+      status: 200,
+      description: 'Custom mood category deleted successfully',
+      schema: {
+        example: {
+          id: 1,
+          customMoodCategories: ['uplifting', 'energetic'],
+        },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized - Invalid or missing JWT token',
+      schema: {
+        example: {
+          statusCode: 401,
+          message: 'Unauthorized',
+          error: 'Unauthorized',
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'Category not found',
+      schema: {
+        example: {
+          statusCode: 404,
+          message: 'Category not found',
+          error: 'Not Found',
+        },
+      },
+    }),
+  );
+}
+
+export function GetContentRecommendationsForMoodDocs() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Get content recommendations for mood',
+      description:
+        'Get personalized content recommendations based on mood and intensity level',
+    }),
+    ApiBody({
+      schema: {
+        type: 'object',
+        required: ['mood', 'intensity'],
+        properties: {
+          mood: { type: 'string', example: 'happy' },
+          intensity: { type: 'number', example: 4 },
+          preferredContentTypes: {
+            type: 'array',
+            items: { type: 'string' },
+            example: ['comedy', 'pop'],
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 200,
+      description: 'Content recommendations retrieved successfully',
+      schema: {
+        example: {
+          contentTypes: ['comedy', 'pop'],
+          intensity: 4,
+          mood: 'happy',
+          isDefault: false,
+          moodPreferences: {
+            intensityLevels: [1, 2, 3, 4, 5],
+            preferredContentTypes: ['comedy', 'pop'],
+            customCategories: ['uplifting'],
+            defaultPreferences: {
+              contentTypes: ['comedy', 'pop'],
+              intensityThreshold: 3,
+            },
+          },
+          intensitySettings: {
+            minIntensity: 1,
+            maxIntensity: 5,
+            contentMappings: {
+              comedy: { minIntensity: 1, maxIntensity: 5, priority: 1 },
+              pop: { minIntensity: 1, maxIntensity: 5, priority: 2 },
+            },
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized - Invalid or missing JWT token',
+      schema: {
+        example: {
+          statusCode: 401,
+          message: 'Unauthorized',
+          error: 'Unauthorized',
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'User preferences not found',
+      schema: {
+        example: {
+          statusCode: 404,
+          message: 'User preferences not found',
+          error: 'Not Found',
+        },
+      },
+    }),
+  );
+}
+
+export function ResetMoodPreferencesDocs() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Reset mood preferences',
+      description:
+        "Reset mood preferences for the authenticated user. If a mood is specified, only that mood's preferences are reset.",
+    }),
+    ApiQuery({
+      name: 'mood',
+      required: false,
+      description: 'Specific mood to reset preferences for',
+    }),
+    ApiResponse({
+      status: 200,
+      description: 'Mood preferences reset successfully',
+      schema: {
+        example: {
+          id: 1,
+          theme: 'light',
+          notificationsEnabled: true,
+          preferredContentTypes: ['movie', 'music'],
+          moodPreferences: {},
+          moodIntensitySettings: {},
+          customMoodCategories: [],
+          defaultIntensityLevels: 5,
+          enableMoodIntensity: true,
+          enableCustomMoodCategories: true,
+        },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized - Invalid or missing JWT token',
+      schema: {
+        example: {
+          statusCode: 401,
+          message: 'Unauthorized',
+          error: 'Unauthorized',
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'User preferences not found',
+      schema: {
+        example: {
+          statusCode: 404,
+          message: 'User preferences not found',
+          error: 'Not Found',
+        },
+      },
+    }),
+  );
+}

--- a/src/modules/user-preferences/docs/user-preferences.docs.ts
+++ b/src/modules/user-preferences/docs/user-preferences.docs.ts
@@ -61,8 +61,9 @@ export function GetUserPreferencesDocs() {
 export function UpdateUserPreferencesDocs() {
   return applyDecorators(
     ApiOperation({
-      summary: 'Update user preferences',
-      description: 'Update user preferences for the authenticated user',
+      summary: 'Update (upsert) user preferences',
+      description:
+        'Upsert user preferences for the authenticated user. If preferences do not exist yet, this will create them; otherwise it will update the existing record.',
     }),
     ApiBearerAuth('JWT-auth'),
     ApiBody({

--- a/src/modules/user-preferences/dto/mood-preference.dto.ts
+++ b/src/modules/user-preferences/dto/mood-preference.dto.ts
@@ -1,0 +1,120 @@
+import {
+  IsString,
+  IsArray,
+  IsNumber,
+  IsOptional,
+  IsBoolean,
+  ValidateNested,
+  IsObject,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class DefaultPreferencesDto {
+  @IsArray()
+  @IsString({ each: true })
+  contentTypes: string[];
+
+  @IsNumber()
+  intensityThreshold: number;
+}
+
+export class MoodPreferenceDto {
+  @IsArray()
+  @IsNumber({}, { each: true })
+  intensityLevels: number[];
+
+  @IsArray()
+  @IsString({ each: true })
+  preferredContentTypes: string[];
+
+  @IsArray()
+  @IsString({ each: true })
+  customCategories: string[];
+
+  @IsObject()
+  @ValidateNested()
+  @Type(() => DefaultPreferencesDto)
+  defaultPreferences: DefaultPreferencesDto;
+}
+
+export class ContentMappingDto {
+  @IsNumber()
+  minIntensity: number;
+
+  @IsNumber()
+  maxIntensity: number;
+
+  @IsNumber()
+  priority: number;
+}
+
+export class MoodIntensitySettingsDto {
+  @IsNumber()
+  minIntensity: number;
+
+  @IsNumber()
+  maxIntensity: number;
+
+  @IsObject()
+  contentMappings: {
+    [contentType: string]: ContentMappingDto;
+  };
+}
+
+export class UpdateMoodPreferencesDto {
+  @IsOptional()
+  @IsString()
+  mood?: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => MoodPreferenceDto)
+  moodPreference?: MoodPreferenceDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => MoodIntensitySettingsDto)
+  intensitySettings?: MoodIntensitySettingsDto;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  customMoodCategories?: string[];
+
+  @IsOptional()
+  @IsNumber()
+  defaultIntensityLevels?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  enableMoodIntensity?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  enableCustomMoodCategories?: boolean;
+}
+
+export class CreateMoodCategoryDto {
+  @IsString()
+  categoryName: string;
+
+  @IsString()
+  description?: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  relatedMoods?: string[];
+}
+
+export class MoodIntensityRequestDto {
+  @IsString()
+  mood: string;
+
+  @IsNumber()
+  intensity: number;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  preferredContentTypes?: string[];
+}

--- a/src/modules/user-preferences/entity/user-preferences.entity.ts
+++ b/src/modules/user-preferences/entity/user-preferences.entity.ts
@@ -8,6 +8,30 @@ import {
 import { BaseEntity } from '@entities/base-entity';
 import { UserEntity } from '@modules/user/entity/user.entity';
 
+// Mood preference interface for type safety
+export interface MoodPreference {
+  intensityLevels: number[];
+  preferredContentTypes: string[];
+  customCategories: string[];
+  defaultPreferences: {
+    contentTypes: string[];
+    intensityThreshold: number;
+  };
+}
+
+// Mood intensity settings interface
+export interface MoodIntensitySettings {
+  minIntensity: number;
+  maxIntensity: number;
+  contentMappings: {
+    [contentType: string]: {
+      minIntensity: number;
+      maxIntensity: number;
+      priority: number;
+    };
+  };
+}
+
 @Entity('user_preferences')
 export class UserPreferencesEntity extends BaseEntity {
   @PrimaryGeneratedColumn()
@@ -17,6 +41,7 @@ export class UserPreferencesEntity extends BaseEntity {
   @JoinColumn({ name: 'user_id' })
   user: UserEntity;
 
+  // Basic preferences (existing)
   @Column({ default: 'light' })
   theme: string;
 
@@ -25,4 +50,27 @@ export class UserPreferencesEntity extends BaseEntity {
 
   @Column('simple-array', { nullable: true })
   preferredContentTypes: string[];
+
+  // Mood-specific preferences (new)
+  @Column('json', { nullable: true })
+  moodPreferences: {
+    [mood: string]: MoodPreference;
+  };
+
+  @Column('json', { nullable: true })
+  moodIntensitySettings: {
+    [mood: string]: MoodIntensitySettings;
+  };
+
+  @Column('simple-array', { nullable: true })
+  customMoodCategories: string[];
+
+  @Column({ default: 5 })
+  defaultIntensityLevels: number; // Default number of intensity levels (1-5, 1-10, etc.)
+
+  @Column({ default: true })
+  enableMoodIntensity: boolean; // Toggle for mood intensity feature
+
+  @Column({ default: true })
+  enableCustomMoodCategories: boolean; // Toggle for custom mood categories
 }

--- a/src/modules/user-preferences/user-preferences.controller.ts
+++ b/src/modules/user-preferences/user-preferences.controller.ts
@@ -1,4 +1,15 @@
-import { Controller, Get, Put, Body, Request, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Put,
+  Post,
+  Delete,
+  Body,
+  Request,
+  UseGuards,
+  Param,
+  Query,
+} from '@nestjs/common';
 import { UserPreferencesService } from './user-preferences.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import {
@@ -6,7 +17,20 @@ import {
   GetUserPreferencesDocs,
   UpdateUserPreferencesDocs,
 } from './docs/user-preferences.docs';
+import {
+  GetMoodPreferencesDocs,
+  UpdateMoodPreferencesDocs,
+  CreateCustomMoodCategoryDocs,
+  DeleteCustomMoodCategoryDocs,
+  GetContentRecommendationsForMoodDocs,
+  ResetMoodPreferencesDocs,
+} from './docs/mood-preferences.docs';
 import { ApiBearerAuth } from '@nestjs/swagger';
+import {
+  UpdateMoodPreferencesDto,
+  CreateMoodCategoryDto,
+  MoodIntensityRequestDto,
+} from './dto/mood-preference.dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller('user/preferences')
@@ -15,6 +39,7 @@ import { ApiBearerAuth } from '@nestjs/swagger';
 export class UserPreferencesController {
   constructor(private readonly prefsService: UserPreferencesService) {}
 
+  // Existing basic preference endpoints
   @Get()
   @GetUserPreferencesDocs()
   async getPreferences(@Request() req) {
@@ -25,5 +50,66 @@ export class UserPreferencesController {
   @UpdateUserPreferencesDocs()
   async updatePreferences(@Request() req, @Body() body) {
     return this.prefsService.createOrUpdate(req.user.userId, body);
+  }
+
+  // New mood-specific preference endpoints
+  @Get('mood')
+  @GetMoodPreferencesDocs()
+  async getMoodPreferences(@Request() req, @Query('mood') mood?: string) {
+    return this.prefsService.getMoodPreferences(req.user.userId, mood);
+  }
+
+  @Put('mood')
+  @UpdateMoodPreferencesDocs()
+  async updateMoodPreferences(
+    @Request() req,
+    @Body() moodPreferencesDto: UpdateMoodPreferencesDto,
+  ) {
+    return this.prefsService.updateMoodPreferences(
+      req.user.userId,
+      moodPreferencesDto,
+    );
+  }
+
+  @Post('mood/categories')
+  @CreateCustomMoodCategoryDocs()
+  async createCustomMoodCategory(
+    @Request() req,
+    @Body() categoryDto: CreateMoodCategoryDto,
+  ) {
+    return this.prefsService.createCustomMoodCategory(
+      req.user.userId,
+      categoryDto,
+    );
+  }
+
+  @Delete('mood/categories/:categoryName')
+  @DeleteCustomMoodCategoryDocs()
+  async deleteCustomMoodCategory(
+    @Request() req,
+    @Param('categoryName') categoryName: string,
+  ) {
+    return this.prefsService.deleteCustomMoodCategory(
+      req.user.userId,
+      categoryName,
+    );
+  }
+
+  @Post('mood/recommendations')
+  @GetContentRecommendationsForMoodDocs()
+  async getContentRecommendationsForMood(
+    @Request() req,
+    @Body() moodIntensityRequest: MoodIntensityRequestDto,
+  ) {
+    return this.prefsService.getContentRecommendationsForMood(
+      req.user.userId,
+      moodIntensityRequest,
+    );
+  }
+
+  @Delete('mood/reset')
+  @ResetMoodPreferencesDocs()
+  async resetMoodPreferences(@Request() req, @Query('mood') mood?: string) {
+    return this.prefsService.resetMoodPreferences(req.user.userId, mood);
   }
 }

--- a/src/modules/user-preferences/user-preferences.service.spec.ts
+++ b/src/modules/user-preferences/user-preferences.service.spec.ts
@@ -4,6 +4,12 @@ import { UserPreferencesService } from './user-preferences.service';
 import { UserPreferencesEntity } from './entity/user-preferences.entity';
 import { Repository } from 'typeorm';
 import { TestAuthUtils, MockUser } from '../../../test/test-utils';
+import {
+  UpdateMoodPreferencesDto,
+  CreateMoodCategoryDto,
+  MoodIntensityRequestDto,
+} from './dto/mood-preference.dto';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
 
 describe('UserPreferencesService', () => {
   let service: UserPreferencesService;
@@ -15,7 +21,6 @@ describe('UserPreferencesService', () => {
     save: jest.fn(),
   };
 
-  // Mock user for testing
   const mockUser: MockUser = TestAuthUtils.createMockUser();
 
   const mockUserPreferences: UserPreferencesEntity = {
@@ -31,6 +36,31 @@ describe('UserPreferencesService', () => {
     theme: 'dark',
     notificationsEnabled: true,
     preferredContentTypes: ['movie', 'music'],
+    moodPreferences: {
+      happy: {
+        intensityLevels: [1, 2, 3, 4, 5],
+        preferredContentTypes: ['comedy', 'pop'],
+        customCategories: ['uplifting'],
+        defaultPreferences: {
+          contentTypes: ['comedy', 'pop'],
+          intensityThreshold: 3,
+        },
+      },
+    },
+    moodIntensitySettings: {
+      happy: {
+        minIntensity: 1,
+        maxIntensity: 5,
+        contentMappings: {
+          comedy: { minIntensity: 1, maxIntensity: 5, priority: 1 },
+          pop: { minIntensity: 1, maxIntensity: 5, priority: 2 },
+        },
+      },
+    },
+    customMoodCategories: ['uplifting', 'energetic'],
+    defaultIntensityLevels: 5,
+    enableMoodIntensity: true,
+    enableCustomMoodCategories: true,
     createdAt: new Date(),
     updatedAt: new Date(),
   };
@@ -59,9 +89,7 @@ describe('UserPreferencesService', () => {
   describe('findByUserId', () => {
     it('should find user preferences by user ID', async () => {
       mockRepository.findOne.mockResolvedValue(mockUserPreferences);
-
       const result = await service.findByUserId(mockUser.id);
-
       expect(result).toEqual(mockUserPreferences);
       expect(repository.findOne).toHaveBeenCalledWith({
         where: { user: { id: mockUser.id } },
@@ -70,47 +98,12 @@ describe('UserPreferencesService', () => {
 
     it('should return null when user preferences not found', async () => {
       mockRepository.findOne.mockResolvedValue(null);
-
       const result = await service.findByUserId(999);
-
       expect(result).toBeNull();
-      expect(repository.findOne).toHaveBeenCalledWith({
-        where: { user: { id: 999 } },
-      });
-    });
-
-    it('should handle different user IDs', async () => {
-      const differentUser = TestAuthUtils.createMockUser({
-        id: 2,
-        email: 'user2@example.com',
-      });
-
-      const differentPreferences = {
-        ...mockUserPreferences,
-        id: 2,
-        user: {
-          id: differentUser.id,
-          email: differentUser.email,
-          password: differentUser.password,
-          moods: [],
-          createdAt: differentUser.createdAt,
-          updatedAt: differentUser.updatedAt,
-        },
-      };
-
-      mockRepository.findOne.mockResolvedValue(differentPreferences);
-
-      const result = await service.findByUserId(differentUser.id);
-
-      expect(result).toEqual(differentPreferences);
-      expect(repository.findOne).toHaveBeenCalledWith({
-        where: { user: { id: differentUser.id } },
-      });
     });
 
     it('should handle repository errors gracefully', async () => {
       mockRepository.findOne.mockRejectedValue(new Error('Database error'));
-
       await expect(service.findByUserId(mockUser.id)).rejects.toThrow(
         'Database error',
       );
@@ -125,131 +118,258 @@ describe('UserPreferencesService', () => {
     };
 
     it('should update existing user preferences', async () => {
-      const updatedPreferences = {
-        ...mockUserPreferences,
-        ...updateData,
-      };
-
+      const updatedPreferences = { ...mockUserPreferences, ...updateData };
       mockRepository.findOne.mockResolvedValue(mockUserPreferences);
       mockRepository.save.mockResolvedValue(updatedPreferences);
-
       const result = await service.createOrUpdate(mockUser.id, updateData);
-
       expect(result).toEqual(updatedPreferences);
-      expect(repository.findOne).toHaveBeenCalledWith({
-        where: { user: { id: mockUser.id } },
-      });
-      expect(repository.save).toHaveBeenCalledWith(updatedPreferences);
     });
 
     it('should create new user preferences when none exist', async () => {
-      const newPreferences = {
-        ...mockUserPreferences,
-        id: 2,
-        ...updateData,
-      };
-
+      const newPreferences = { ...mockUserPreferences, id: 2, ...updateData };
       mockRepository.findOne.mockResolvedValue(null);
       mockRepository.create.mockReturnValue(newPreferences);
       mockRepository.save.mockResolvedValue(newPreferences);
-
       const result = await service.createOrUpdate(mockUser.id, updateData);
-
       expect(result).toEqual(newPreferences);
-      expect(repository.findOne).toHaveBeenCalledWith({
-        where: { user: { id: mockUser.id } },
-      });
-      expect(repository.create).toHaveBeenCalledWith({
-        ...updateData,
-        user: { id: mockUser.id },
-      });
-      expect(repository.save).toHaveBeenCalledWith(newPreferences);
-    });
-
-    it('should handle partial updates', async () => {
-      const partialUpdate = { theme: 'light' };
-      const updatedPreferences = {
-        ...mockUserPreferences,
-        theme: 'light',
-      };
-
-      mockRepository.findOne.mockResolvedValue(mockUserPreferences);
-      mockRepository.save.mockResolvedValue(updatedPreferences);
-
-      const result = await service.createOrUpdate(mockUser.id, partialUpdate);
-
-      expect(result).toEqual(updatedPreferences);
-      expect(repository.save).toHaveBeenCalledWith(updatedPreferences);
-    });
-
-    it('should handle different user contexts', async () => {
-      const differentUser = TestAuthUtils.createMockUser({
-        id: 3,
-        email: 'user3@example.com',
-      });
-
-      const differentPreferences = {
-        ...mockUserPreferences,
-        id: 3,
-        user: {
-          id: differentUser.id,
-          email: differentUser.email,
-          password: differentUser.password,
-          moods: [],
-          createdAt: differentUser.createdAt,
-          updatedAt: differentUser.updatedAt,
-        },
-        theme: 'custom',
-      };
-
-      mockRepository.findOne.mockResolvedValue(differentPreferences);
-      mockRepository.save.mockResolvedValue(differentPreferences);
-
-      const result = await service.createOrUpdate(differentUser.id, updateData);
-
-      expect(result).toEqual(differentPreferences);
-      expect(repository.findOne).toHaveBeenCalledWith({
-        where: { user: { id: differentUser.id } },
-      });
     });
 
     it('should handle repository errors during update', async () => {
       mockRepository.findOne.mockResolvedValue(mockUserPreferences);
       mockRepository.save.mockRejectedValue(new Error('Save error'));
-
       await expect(
         service.createOrUpdate(mockUser.id, updateData),
       ).rejects.toThrow('Save error');
     });
+  });
 
-    it('should handle repository errors during creation', async () => {
+  // New mood-specific preference tests
+  describe('updateMoodPreferences', () => {
+    const moodPreferencesDto: UpdateMoodPreferencesDto = {
+      mood: 'happy',
+      moodPreference: {
+        intensityLevels: [1, 2, 3, 4, 5],
+        preferredContentTypes: ['comedy', 'pop'],
+        customCategories: ['uplifting'],
+        defaultPreferences: {
+          contentTypes: ['comedy', 'pop'],
+          intensityThreshold: 3,
+        },
+      },
+    };
+
+    it('should update mood preferences for existing user preferences', async () => {
+      const updatedPreferences = { ...mockUserPreferences };
+      mockRepository.findOne.mockResolvedValue(mockUserPreferences);
+      mockRepository.save.mockResolvedValue(updatedPreferences);
+      const result = await service.updateMoodPreferences(
+        mockUser.id,
+        moodPreferencesDto,
+      );
+      expect(result).toEqual(updatedPreferences);
+    });
+
+    it('should create new user preferences with mood preferences when none exist', async () => {
+      const newPreferences = { ...mockUserPreferences, id: 2 };
       mockRepository.findOne.mockResolvedValue(null);
-      mockRepository.create.mockReturnValue(mockUserPreferences);
-      mockRepository.save.mockRejectedValue(new Error('Create error'));
+      mockRepository.create.mockReturnValue(newPreferences);
+      mockRepository.save.mockResolvedValue(newPreferences);
+      const result = await service.updateMoodPreferences(
+        mockUser.id,
+        moodPreferencesDto,
+      );
+      expect(result).toEqual(newPreferences);
+    });
+  });
 
+  describe('getMoodPreferences', () => {
+    it('should get all mood preferences when no specific mood is provided', async () => {
+      mockRepository.findOne.mockResolvedValue(mockUserPreferences);
+      const result = await service.getMoodPreferences(mockUser.id);
+      expect(result).toEqual({
+        moodPreferences: mockUserPreferences.moodPreferences,
+        moodIntensitySettings: mockUserPreferences.moodIntensitySettings,
+        customMoodCategories: mockUserPreferences.customMoodCategories,
+        defaultIntensityLevels: mockUserPreferences.defaultIntensityLevels,
+        enableMoodIntensity: mockUserPreferences.enableMoodIntensity,
+        enableCustomMoodCategories:
+          mockUserPreferences.enableCustomMoodCategories,
+      });
+    });
+
+    it('should get specific mood preferences when mood is provided', async () => {
+      mockRepository.findOne.mockResolvedValue(mockUserPreferences);
+      const result = await service.getMoodPreferences(mockUser.id, 'happy');
+      expect(result).toEqual({
+        mood: 'happy',
+        preferences: mockUserPreferences.moodPreferences['happy'],
+        intensitySettings: mockUserPreferences.moodIntensitySettings['happy'],
+        defaultIntensityLevels: mockUserPreferences.defaultIntensityLevels,
+        enableMoodIntensity: mockUserPreferences.enableMoodIntensity,
+      });
+    });
+
+    it('should throw NotFoundException when user preferences not found', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+      await expect(service.getMoodPreferences(mockUser.id)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw NotFoundException when specific mood preferences not found', async () => {
+      mockRepository.findOne.mockResolvedValue(mockUserPreferences);
       await expect(
-        service.createOrUpdate(mockUser.id, updateData),
-      ).rejects.toThrow('Create error');
+        service.getMoodPreferences(mockUser.id, 'sad'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('createCustomMoodCategory', () => {
+    const categoryDto: CreateMoodCategoryDto = {
+      categoryName: 'new-category',
+      description: 'A new mood category',
+      relatedMoods: ['happy', 'excited'],
+    };
+
+    it('should create custom mood category for existing user preferences', async () => {
+      const updatedPreferences = { ...mockUserPreferences };
+      mockRepository.findOne.mockResolvedValue(mockUserPreferences);
+      mockRepository.save.mockResolvedValue(updatedPreferences);
+      const result = await service.createCustomMoodCategory(
+        mockUser.id,
+        categoryDto,
+      );
+      expect(result).toEqual(updatedPreferences);
     });
 
-    it('should handle empty update data', async () => {
-      mockRepository.findOne.mockResolvedValue(mockUserPreferences);
-      mockRepository.save.mockResolvedValue(mockUserPreferences);
-
-      const result = await service.createOrUpdate(mockUser.id, {});
-
-      expect(result).toEqual(mockUserPreferences);
-      expect(repository.save).toHaveBeenCalledWith(mockUserPreferences);
+    it('should create new user preferences with custom mood category when none exist', async () => {
+      const newPreferences = {
+        ...mockUserPreferences,
+        id: 2,
+        customMoodCategories: [],
+      };
+      mockRepository.findOne.mockResolvedValue(null);
+      mockRepository.create.mockReturnValue(newPreferences);
+      mockRepository.save.mockResolvedValue(newPreferences);
+      const result = await service.createCustomMoodCategory(
+        mockUser.id,
+        categoryDto,
+      );
+      expect(result).toEqual(newPreferences);
     });
 
-    it('should handle null update data', async () => {
+    it('should throw BadRequestException when category already exists', async () => {
       mockRepository.findOne.mockResolvedValue(mockUserPreferences);
-      mockRepository.save.mockResolvedValue(mockUserPreferences);
+      await expect(
+        service.createCustomMoodCategory(mockUser.id, {
+          categoryName: 'uplifting',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
 
-      const result = await service.createOrUpdate(mockUser.id, null);
+  describe('deleteCustomMoodCategory', () => {
+    it('should delete custom mood category successfully', async () => {
+      const updatedPreferences = { ...mockUserPreferences };
+      mockRepository.findOne.mockResolvedValue(mockUserPreferences);
+      mockRepository.save.mockResolvedValue(updatedPreferences);
+      const result = await service.deleteCustomMoodCategory(
+        mockUser.id,
+        'uplifting',
+      );
+      expect(result).toEqual(updatedPreferences);
+    });
 
-      expect(result).toEqual(mockUserPreferences);
-      expect(repository.save).toHaveBeenCalledWith(mockUserPreferences);
+    it('should throw NotFoundException when user preferences not found', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+      await expect(
+        service.deleteCustomMoodCategory(mockUser.id, 'uplifting'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw NotFoundException when category not found', async () => {
+      mockRepository.findOne.mockResolvedValue(mockUserPreferences);
+      await expect(
+        service.deleteCustomMoodCategory(mockUser.id, 'non-existent'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getContentRecommendationsForMood', () => {
+    const moodIntensityRequest: MoodIntensityRequestDto = {
+      mood: 'happy',
+      intensity: 4,
+      preferredContentTypes: ['comedy', 'pop'],
+    };
+
+    it('should return content recommendations for mood with preferences', async () => {
+      mockRepository.findOne.mockResolvedValue(mockUserPreferences);
+      const result = await service.getContentRecommendationsForMood(
+        mockUser.id,
+        moodIntensityRequest,
+      );
+      expect(result).toEqual({
+        contentTypes: ['comedy', 'pop'],
+        intensity: 4,
+        mood: 'happy',
+        isDefault: false,
+        moodPreferences: mockUserPreferences.moodPreferences['happy'],
+        intensitySettings: mockUserPreferences.moodIntensitySettings['happy'],
+      });
+    });
+
+    it('should return default recommendations when no mood preferences exist', async () => {
+      const userPrefsWithoutMood = {
+        ...mockUserPreferences,
+        moodPreferences: {},
+        moodIntensitySettings: {},
+      };
+      mockRepository.findOne.mockResolvedValue(userPrefsWithoutMood);
+      const result = await service.getContentRecommendationsForMood(
+        mockUser.id,
+        moodIntensityRequest,
+      );
+      expect(result).toEqual({
+        contentTypes: userPrefsWithoutMood.preferredContentTypes,
+        intensity: 4,
+        mood: 'happy',
+        isDefault: true,
+      });
+    });
+
+    it('should throw NotFoundException when user preferences not found', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+      await expect(
+        service.getContentRecommendationsForMood(
+          mockUser.id,
+          moodIntensityRequest,
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('resetMoodPreferences', () => {
+    it('should reset all mood preferences when no specific mood is provided', async () => {
+      const updatedPreferences = { ...mockUserPreferences };
+      mockRepository.findOne.mockResolvedValue(mockUserPreferences);
+      mockRepository.save.mockResolvedValue(updatedPreferences);
+      const result = await service.resetMoodPreferences(mockUser.id);
+      expect(result).toEqual(updatedPreferences);
+    });
+
+    it('should reset specific mood preferences when mood is provided', async () => {
+      const updatedPreferences = { ...mockUserPreferences };
+      mockRepository.findOne.mockResolvedValue(mockUserPreferences);
+      mockRepository.save.mockResolvedValue(updatedPreferences);
+      const result = await service.resetMoodPreferences(mockUser.id, 'happy');
+      expect(result).toEqual(updatedPreferences);
+    });
+
+    it('should throw NotFoundException when user preferences not found', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+      await expect(service.resetMoodPreferences(mockUser.id)).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/src/modules/user-preferences/user-preferences.service.ts
+++ b/src/modules/user-preferences/user-preferences.service.ts
@@ -1,7 +1,16 @@
-import { Injectable } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UserPreferencesEntity } from './entity/user-preferences.entity';
+import {
+  UpdateMoodPreferencesDto,
+  CreateMoodCategoryDto,
+  MoodIntensityRequestDto,
+} from './dto/mood-preference.dto';
 
 @Injectable()
 export class UserPreferencesService {
@@ -10,6 +19,7 @@ export class UserPreferencesService {
     private readonly preferencesRepo: Repository<UserPreferencesEntity>,
   ) {}
 
+  // Existing basic preference methods
   async findByUserId(userId: number) {
     return this.preferencesRepo.findOne({ where: { user: { id: userId } } });
   }
@@ -23,5 +33,222 @@ export class UserPreferencesService {
       prefs = this.preferencesRepo.create({ ...data, user: { id: userId } });
       return this.preferencesRepo.save(prefs);
     }
+  }
+
+  // New mood-specific preference methods
+  async updateMoodPreferences(
+    userId: number,
+    moodPreferencesDto: UpdateMoodPreferencesDto,
+  ) {
+    let prefs = await this.findByUserId(userId);
+    if (!prefs) {
+      prefs = this.preferencesRepo.create({
+        user: { id: userId },
+        moodPreferences: {},
+        moodIntensitySettings: {},
+        customMoodCategories: [],
+      });
+    }
+
+    // Update mood-specific preferences
+    if (moodPreferencesDto.mood && moodPreferencesDto.moodPreference) {
+      if (!prefs.moodPreferences) {
+        prefs.moodPreferences = {};
+      }
+      prefs.moodPreferences[moodPreferencesDto.mood] =
+        moodPreferencesDto.moodPreference;
+    }
+
+    // Update intensity settings
+    if (moodPreferencesDto.mood && moodPreferencesDto.intensitySettings) {
+      if (!prefs.moodIntensitySettings) {
+        prefs.moodIntensitySettings = {};
+      }
+      prefs.moodIntensitySettings[moodPreferencesDto.mood] =
+        moodPreferencesDto.intensitySettings;
+    }
+
+    // Update other mood-related settings
+    if (moodPreferencesDto.customMoodCategories !== undefined) {
+      prefs.customMoodCategories = moodPreferencesDto.customMoodCategories;
+    }
+
+    if (moodPreferencesDto.defaultIntensityLevels !== undefined) {
+      prefs.defaultIntensityLevels = moodPreferencesDto.defaultIntensityLevels;
+    }
+
+    if (moodPreferencesDto.enableMoodIntensity !== undefined) {
+      prefs.enableMoodIntensity = moodPreferencesDto.enableMoodIntensity;
+    }
+
+    if (moodPreferencesDto.enableCustomMoodCategories !== undefined) {
+      prefs.enableCustomMoodCategories =
+        moodPreferencesDto.enableCustomMoodCategories;
+    }
+
+    return this.preferencesRepo.save(prefs);
+  }
+
+  async getMoodPreferences(userId: number, mood?: string) {
+    const prefs = await this.findByUserId(userId);
+    if (!prefs) {
+      throw new NotFoundException('User preferences not found');
+    }
+
+    if (mood) {
+      const moodPref = prefs.moodPreferences?.[mood];
+      const intensitySettings = prefs.moodIntensitySettings?.[mood];
+
+      if (!moodPref && !intensitySettings) {
+        throw new NotFoundException(`No preferences found for mood: ${mood}`);
+      }
+
+      return {
+        mood,
+        preferences: moodPref,
+        intensitySettings,
+        defaultIntensityLevels: prefs.defaultIntensityLevels,
+        enableMoodIntensity: prefs.enableMoodIntensity,
+      };
+    }
+
+    return {
+      moodPreferences: prefs.moodPreferences || {},
+      moodIntensitySettings: prefs.moodIntensitySettings || {},
+      customMoodCategories: prefs.customMoodCategories || [],
+      defaultIntensityLevels: prefs.defaultIntensityLevels,
+      enableMoodIntensity: prefs.enableMoodIntensity,
+      enableCustomMoodCategories: prefs.enableCustomMoodCategories,
+    };
+  }
+
+  async createCustomMoodCategory(
+    userId: number,
+    categoryDto: CreateMoodCategoryDto,
+  ) {
+    let prefs = await this.findByUserId(userId);
+    if (!prefs) {
+      prefs = this.preferencesRepo.create({
+        user: { id: userId },
+        customMoodCategories: [],
+      });
+    }
+
+    if (!prefs.customMoodCategories) {
+      prefs.customMoodCategories = [];
+    }
+
+    // Check if category already exists
+    if (prefs.customMoodCategories.includes(categoryDto.categoryName)) {
+      throw new BadRequestException(
+        `Mood category '${categoryDto.categoryName}' already exists`,
+      );
+    }
+
+    prefs.customMoodCategories.push(categoryDto.categoryName);
+    return this.preferencesRepo.save(prefs);
+  }
+
+  async deleteCustomMoodCategory(userId: number, categoryName: string) {
+    const prefs = await this.findByUserId(userId);
+    if (!prefs || !prefs.customMoodCategories) {
+      throw new NotFoundException('No custom mood categories found');
+    }
+
+    const index = prefs.customMoodCategories.indexOf(categoryName);
+    if (index === -1) {
+      throw new NotFoundException(`Mood category '${categoryName}' not found`);
+    }
+
+    prefs.customMoodCategories.splice(index, 1);
+    return this.preferencesRepo.save(prefs);
+  }
+
+  async getContentRecommendationsForMood(
+    userId: number,
+    moodIntensityRequest: MoodIntensityRequestDto,
+  ) {
+    const prefs = await this.findByUserId(userId);
+    if (!prefs) {
+      throw new NotFoundException('User preferences not found');
+    }
+
+    const { mood, intensity, preferredContentTypes } = moodIntensityRequest;
+    const moodPref = prefs.moodPreferences?.[mood];
+    const intensitySettings = prefs.moodIntensitySettings?.[mood];
+
+    if (!moodPref && !intensitySettings) {
+      // Return default recommendations based on general preferences
+      return {
+        contentTypes: prefs.preferredContentTypes || ['movie', 'music'],
+        intensity: intensity,
+        mood: mood,
+        isDefault: true,
+      };
+    }
+
+    // Get content types based on intensity
+    let recommendedContentTypes = moodPref?.preferredContentTypes ||
+      prefs.preferredContentTypes || ['movie', 'music'];
+
+    // Filter by intensity if settings exist
+    if (intensitySettings?.contentMappings) {
+      const intensityFilteredTypes = Object.entries(
+        intensitySettings.contentMappings,
+      )
+        .filter(([, mapping]) => {
+          return (
+            intensity >= mapping.minIntensity &&
+            intensity <= mapping.maxIntensity
+          );
+        })
+        .sort((a, b) => b[1].priority - a[1].priority)
+        .map(([contentType]) => contentType);
+
+      if (intensityFilteredTypes.length > 0) {
+        recommendedContentTypes = intensityFilteredTypes;
+      }
+    }
+
+    // Override with user's specific preferences if provided
+    if (preferredContentTypes && preferredContentTypes.length > 0) {
+      recommendedContentTypes = preferredContentTypes;
+    }
+
+    return {
+      contentTypes: recommendedContentTypes,
+      intensity: intensity,
+      mood: mood,
+      isDefault: !moodPref && !intensitySettings,
+      moodPreferences: moodPref,
+      intensitySettings: intensitySettings,
+    };
+  }
+
+  async resetMoodPreferences(userId: number, mood?: string) {
+    const prefs = await this.findByUserId(userId);
+    if (!prefs) {
+      throw new NotFoundException('User preferences not found');
+    }
+
+    if (mood) {
+      // Reset specific mood preferences
+      if (prefs.moodPreferences?.[mood]) {
+        delete prefs.moodPreferences[mood];
+      }
+      if (prefs.moodIntensitySettings?.[mood]) {
+        delete prefs.moodIntensitySettings[mood];
+      }
+    } else {
+      // Reset all mood preferences
+      prefs.moodPreferences = {};
+      prefs.moodIntensitySettings = {};
+      prefs.customMoodCategories = [];
+      prefs.defaultIntensityLevels = 5;
+      prefs.enableMoodIntensity = true;
+      prefs.enableCustomMoodCategories = true;
+    }
+
+    return this.preferencesRepo.save(prefs);
   }
 }

--- a/test/mood-preferences.e2e-spec.ts
+++ b/test/mood-preferences.e2e-spec.ts
@@ -1,0 +1,428 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { TestAuthUtils } from './test-utils';
+
+describe('Mood Preferences (e2e)', () => {
+  let app: INestApplication;
+  let validToken: string;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    validToken = TestAuthUtils.generateValidToken();
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  describe('GET /user/preferences/mood', () => {
+    it('should return 401 for missing authentication', async () => {
+      await request(app.getHttpServer())
+        .get('/user/preferences/mood')
+        .expect(401);
+    });
+
+    it('should return 200 and all mood preferences with valid authentication', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/user/preferences/mood')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(200);
+
+      expect(response.body).toBeDefined();
+      if (response.body) {
+        expect(response.body).toHaveProperty('moodPreferences');
+        expect(response.body).toHaveProperty('moodIntensitySettings');
+        expect(response.body).toHaveProperty('customMoodCategories');
+        expect(response.body).toHaveProperty('defaultIntensityLevels');
+        expect(response.body).toHaveProperty('enableMoodIntensity');
+        expect(response.body).toHaveProperty('enableCustomMoodCategories');
+      }
+    });
+
+    it('should return specific mood preferences when mood query parameter is provided', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/user/preferences/mood?mood=happy')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(200);
+
+      expect(response.body).toBeDefined();
+      if (response.body) {
+        expect(response.body).toHaveProperty('mood');
+        expect(response.body.mood).toBe('happy');
+      }
+    });
+  });
+
+  describe('PUT /user/preferences/mood', () => {
+    const moodPreferencesData = {
+      mood: 'happy',
+      moodPreference: {
+        intensityLevels: [1, 2, 3, 4, 5],
+        preferredContentTypes: ['comedy', 'pop'],
+        customCategories: ['uplifting'],
+        defaultPreferences: {
+          contentTypes: ['comedy', 'pop'],
+          intensityThreshold: 3,
+        },
+      },
+      intensitySettings: {
+        minIntensity: 1,
+        maxIntensity: 5,
+        contentMappings: {
+          comedy: { minIntensity: 1, maxIntensity: 5, priority: 1 },
+          pop: { minIntensity: 1, maxIntensity: 5, priority: 2 },
+        },
+      },
+    };
+
+    it('should return 401 for missing authentication', async () => {
+      await request(app.getHttpServer())
+        .put('/user/preferences/mood')
+        .send(moodPreferencesData)
+        .expect(401);
+    });
+
+    it('should return 200 and update mood preferences with valid authentication', async () => {
+      const response = await request(app.getHttpServer())
+        .put('/user/preferences/mood')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send(moodPreferencesData)
+        .expect(200);
+
+      expect(response.body).toBeDefined();
+      if (response.body) {
+        expect(response.body).toHaveProperty('moodPreferences');
+        expect(response.body.moodPreferences).toHaveProperty('happy');
+        expect(response.body).toHaveProperty('moodIntensitySettings');
+        expect(response.body.moodIntensitySettings).toHaveProperty('happy');
+      }
+    });
+
+    it('should handle partial mood preference updates', async () => {
+      const partialUpdate = {
+        mood: 'sad',
+        moodPreference: {
+          intensityLevels: [1, 2, 3],
+          preferredContentTypes: ['drama', 'classical'],
+          customCategories: ['melancholic'],
+          defaultPreferences: {
+            contentTypes: ['drama', 'classical'],
+            intensityThreshold: 2,
+          },
+        },
+      };
+
+      const response = await request(app.getHttpServer())
+        .put('/user/preferences/mood')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send(partialUpdate)
+        .expect(200);
+
+      expect(response.body).toBeDefined();
+    });
+
+    it('should handle general mood settings updates', async () => {
+      const generalSettings = {
+        defaultIntensityLevels: 10,
+        enableMoodIntensity: false,
+        enableCustomMoodCategories: true,
+        customMoodCategories: ['energetic', 'calm', 'focused'],
+      };
+
+      const response = await request(app.getHttpServer())
+        .put('/user/preferences/mood')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send(generalSettings)
+        .expect(200);
+
+      expect(response.body).toBeDefined();
+      if (response.body) {
+        expect(response.body.defaultIntensityLevels).toBe(10);
+        expect(response.body.enableMoodIntensity).toBe(false);
+        expect(response.body.enableCustomMoodCategories).toBe(true);
+        expect(response.body.customMoodCategories).toEqual([
+          'energetic',
+          'calm',
+          'focused',
+        ]);
+      }
+    });
+  });
+
+  describe('POST /user/preferences/mood/categories', () => {
+    const categoryData = {
+      categoryName: 'energetic',
+      description: 'High energy moods',
+      relatedMoods: ['happy', 'excited', 'motivated'],
+    };
+
+    it('should return 401 for missing authentication', async () => {
+      await request(app.getHttpServer())
+        .post('/user/preferences/mood/categories')
+        .send(categoryData)
+        .expect(401);
+    });
+
+    it('should return 201 and create custom mood category with valid authentication', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/user/preferences/mood/categories')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send(categoryData)
+        .expect(201);
+
+      expect(response.body).toBeDefined();
+      if (response.body) {
+        expect(response.body).toHaveProperty('customMoodCategories');
+        expect(response.body.customMoodCategories).toContain('energetic');
+      }
+    });
+
+    it('should handle duplicate category creation', async () => {
+      // First creation
+      await request(app.getHttpServer())
+        .post('/user/preferences/mood/categories')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send(categoryData)
+        .expect(201);
+
+      // Duplicate creation should fail
+      await request(app.getHttpServer())
+        .post('/user/preferences/mood/categories')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send(categoryData)
+        .expect(400);
+    });
+  });
+
+  describe('DELETE /user/preferences/mood/categories/:categoryName', () => {
+    it('should return 401 for missing authentication', async () => {
+      await request(app.getHttpServer())
+        .delete('/user/preferences/mood/categories/test-category')
+        .expect(401);
+    });
+
+    it('should return 200 and delete custom mood category with valid authentication', async () => {
+      // First create a category
+      const categoryData = { categoryName: 'test-category' };
+      await request(app.getHttpServer())
+        .post('/user/preferences/mood/categories')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send(categoryData)
+        .expect(201);
+
+      // Then delete it
+      const response = await request(app.getHttpServer())
+        .delete('/user/preferences/mood/categories/test-category')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(200);
+
+      expect(response.body).toBeDefined();
+    });
+
+    it('should return 404 when trying to delete non-existent category', async () => {
+      await request(app.getHttpServer())
+        .delete('/user/preferences/mood/categories/non-existent-category')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(404);
+    });
+  });
+
+  describe('POST /user/preferences/mood/recommendations', () => {
+    const recommendationRequest = {
+      mood: 'happy',
+      intensity: 4,
+      preferredContentTypes: ['comedy', 'pop'],
+    };
+
+    it('should return 401 for missing authentication', async () => {
+      await request(app.getHttpServer())
+        .post('/user/preferences/mood/recommendations')
+        .send(recommendationRequest)
+        .expect(401);
+    });
+
+    it('should return 200 and get content recommendations with valid authentication', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/user/preferences/mood/recommendations')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send(recommendationRequest)
+        .expect(200);
+
+      expect(response.body).toBeDefined();
+      if (response.body) {
+        expect(response.body).toHaveProperty('contentTypes');
+        expect(response.body).toHaveProperty('intensity');
+        expect(response.body).toHaveProperty('mood');
+        expect(response.body).toHaveProperty('isDefault');
+        expect(response.body.intensity).toBe(4);
+        expect(response.body.mood).toBe('happy');
+      }
+    });
+
+    it('should handle recommendations without specific content types', async () => {
+      const basicRequest = {
+        mood: 'sad',
+        intensity: 2,
+      };
+
+      const response = await request(app.getHttpServer())
+        .post('/user/preferences/mood/recommendations')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send(basicRequest)
+        .expect(200);
+
+      expect(response.body).toBeDefined();
+      expect(response.body.mood).toBe('sad');
+      expect(response.body.intensity).toBe(2);
+    });
+  });
+
+  describe('DELETE /user/preferences/mood/reset', () => {
+    it('should return 401 for missing authentication', async () => {
+      await request(app.getHttpServer())
+        .delete('/user/preferences/mood/reset')
+        .expect(401);
+    });
+
+    it('should return 200 and reset all mood preferences with valid authentication', async () => {
+      const response = await request(app.getHttpServer())
+        .delete('/user/preferences/mood/reset')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(200);
+
+      expect(response.body).toBeDefined();
+      if (response.body) {
+        expect(response.body).toHaveProperty('moodPreferences');
+        expect(response.body).toHaveProperty('moodIntensitySettings');
+        expect(response.body).toHaveProperty('customMoodCategories');
+        expect(response.body).toHaveProperty('defaultIntensityLevels');
+        expect(response.body).toHaveProperty('enableMoodIntensity');
+        expect(response.body).toHaveProperty('enableCustomMoodCategories');
+      }
+    });
+
+    it('should reset specific mood preferences when mood query parameter is provided', async () => {
+      const response = await request(app.getHttpServer())
+        .delete('/user/preferences/mood/reset?mood=happy')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(200);
+
+      expect(response.body).toBeDefined();
+    });
+  });
+
+  describe('User Context Validation', () => {
+    it('should ensure mood preferences are isolated by user', async () => {
+      const user1Token = TestAuthUtils.generateValidToken(
+        1,
+        'user1@example.com',
+      );
+      const user1Data = {
+        mood: 'happy',
+        moodPreference: {
+          intensityLevels: [1, 2, 3, 4, 5],
+          preferredContentTypes: ['comedy'],
+          customCategories: ['uplifting'],
+          defaultPreferences: {
+            contentTypes: ['comedy'],
+            intensityThreshold: 3,
+          },
+        },
+      };
+
+      await request(app.getHttpServer())
+        .put('/user/preferences/mood')
+        .set('Authorization', `Bearer ${user1Token}`)
+        .send(user1Data)
+        .expect(200);
+
+      const user2Token = TestAuthUtils.generateValidToken(
+        2,
+        'user2@example.com',
+      );
+      const user2Data = {
+        mood: 'happy',
+        moodPreference: {
+          intensityLevels: [1, 2, 3],
+          preferredContentTypes: ['drama'],
+          customCategories: ['melancholic'],
+          defaultPreferences: {
+            contentTypes: ['drama'],
+            intensityThreshold: 2,
+          },
+        },
+      };
+
+      const user2Response = await request(app.getHttpServer())
+        .put('/user/preferences/mood')
+        .set('Authorization', `Bearer ${user2Token}`)
+        .send(user2Data)
+        .expect(200);
+
+      expect(
+        user2Response.body.moodPreferences.happy.preferredContentTypes,
+      ).toEqual(['drama']);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle invalid mood preference data', async () => {
+      const invalidData = {
+        mood: 'happy',
+        moodPreference: {
+          intensityLevels: 'invalid', // Should be array
+          preferredContentTypes: 'invalid', // Should be array
+          customCategories: 'invalid', // Should be array
+          defaultPreferences: {
+            contentTypes: 'invalid', // Should be array
+            intensityThreshold: 'invalid', // Should be number
+          },
+        },
+      };
+
+      await request(app.getHttpServer())
+        .put('/user/preferences/mood')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send(invalidData)
+        .expect(400);
+    });
+
+    it('should handle invalid category data', async () => {
+      const invalidCategoryData = {
+        categoryName: '', // Empty name
+        description: 123, // Should be string
+        relatedMoods: 'invalid', // Should be array
+      };
+
+      await request(app.getHttpServer())
+        .post('/user/preferences/mood/categories')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send(invalidCategoryData)
+        .expect(400);
+    });
+
+    it('should handle invalid recommendation request', async () => {
+      const invalidRequest = {
+        mood: '', // Empty mood
+        intensity: 'invalid', // Should be number
+        preferredContentTypes: 'invalid', // Should be array
+      };
+
+      await request(app.getHttpServer())
+        .post('/user/preferences/mood/recommendations')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send(invalidRequest)
+        .expect(400);
+    });
+  });
+});

--- a/test/user-preferences.e2e-spec.ts
+++ b/test/user-preferences.e2e-spec.ts
@@ -26,21 +26,21 @@ describe('UserPreferences (e2e)', () => {
     }
   });
 
-  describe('GET /user-preferences', () => {
+  describe('GET /user/preferences', () => {
     it('should return 401 for missing authentication', async () => {
-      await request(app.getHttpServer()).get('/user-preferences').expect(401);
+      await request(app.getHttpServer()).get('/user/preferences').expect(401);
     });
 
     it('should return 401 for invalid authentication token', async () => {
       await request(app.getHttpServer())
-        .get('/user-preferences')
+        .get('/user/preferences')
         .set('Authorization', 'Bearer invalid-token')
         .expect(401);
     });
 
     it('should return 200 and user preferences with valid authentication', async () => {
       const response = await request(app.getHttpServer())
-        .get('/user-preferences')
+        .get('/user/preferences')
         .set('Authorization', `Bearer ${validToken}`)
         .expect(200);
 
@@ -57,7 +57,7 @@ describe('UserPreferences (e2e)', () => {
     it('should return null when user has no preferences', async () => {
       // This test assumes the user has no preferences set up
       const response = await request(app.getHttpServer())
-        .get('/user-preferences')
+        .get('/user/preferences')
         .set('Authorization', `Bearer ${validToken}`)
         .expect(200);
 
@@ -66,7 +66,7 @@ describe('UserPreferences (e2e)', () => {
     });
   });
 
-  describe('PUT /user-preferences', () => {
+  describe('PUT /user/preferences', () => {
     const updateData = {
       theme: 'light',
       notificationsEnabled: false,
@@ -75,14 +75,14 @@ describe('UserPreferences (e2e)', () => {
 
     it('should return 401 for missing authentication', async () => {
       await request(app.getHttpServer())
-        .put('/user-preferences')
+        .put('/user/preferences')
         .send(updateData)
         .expect(401);
     });
 
     it('should return 401 for invalid authentication token', async () => {
       await request(app.getHttpServer())
-        .put('/user-preferences')
+        .put('/user/preferences')
         .set('Authorization', 'Bearer invalid-token')
         .send(updateData)
         .expect(401);
@@ -90,7 +90,7 @@ describe('UserPreferences (e2e)', () => {
 
     it('should return 200 and update user preferences with valid authentication', async () => {
       const response = await request(app.getHttpServer())
-        .put('/user-preferences')
+        .put('/user/preferences')
         .set('Authorization', `Bearer ${validToken}`)
         .send(updateData)
         .expect(200);
@@ -112,7 +112,7 @@ describe('UserPreferences (e2e)', () => {
       const partialUpdate = { theme: 'dark' };
 
       const response = await request(app.getHttpServer())
-        .put('/user-preferences')
+        .put('/user/preferences')
         .set('Authorization', `Bearer ${validToken}`)
         .send(partialUpdate)
         .expect(200);
@@ -123,7 +123,7 @@ describe('UserPreferences (e2e)', () => {
 
     it('should handle empty update data', async () => {
       const response = await request(app.getHttpServer())
-        .put('/user-preferences')
+        .put('/user/preferences')
         .set('Authorization', `Bearer ${validToken}`)
         .send({})
         .expect(200);
@@ -138,7 +138,7 @@ describe('UserPreferences (e2e)', () => {
       };
 
       await request(app.getHttpServer())
-        .put('/user-preferences')
+        .put('/user/preferences')
         .set('Authorization', `Bearer ${validToken}`)
         .send(invalidData)
         .expect(400);
@@ -150,28 +150,28 @@ describe('UserPreferences (e2e)', () => {
       const expiredToken = TestAuthUtils.generateExpiredToken();
 
       await request(app.getHttpServer())
-        .get('/user-preferences')
+        .get('/user/preferences')
         .set('Authorization', `Bearer ${expiredToken}`)
         .expect(401);
     });
 
     it('should handle malformed tokens', async () => {
       await request(app.getHttpServer())
-        .get('/user-preferences')
+        .get('/user/preferences')
         .set('Authorization', 'Bearer malformed.token.here')
         .expect(401);
     });
 
     it('should handle missing Bearer prefix', async () => {
       await request(app.getHttpServer())
-        .get('/user-preferences')
+        .get('/user/preferences')
         .set('Authorization', validToken)
         .expect(401);
     });
 
     it('should handle empty Authorization header', async () => {
       await request(app.getHttpServer())
-        .get('/user-preferences')
+        .get('/user/preferences')
         .set('Authorization', '')
         .expect(401);
     });
@@ -183,7 +183,7 @@ describe('UserPreferences (e2e)', () => {
       );
 
       const response = await request(app.getHttpServer())
-        .get('/user-preferences')
+        .get('/user/preferences')
         .set('Authorization', `Bearer ${differentUserToken}`)
         .expect(200);
 
@@ -201,7 +201,7 @@ describe('UserPreferences (e2e)', () => {
       const user1Data = { theme: 'light', notificationsEnabled: true };
 
       const user1Response = await request(app.getHttpServer())
-        .put('/user-preferences')
+        .put('/user/preferences')
         .set('Authorization', `Bearer ${user1Token}`)
         .send(user1Data)
         .expect(200);
@@ -214,7 +214,7 @@ describe('UserPreferences (e2e)', () => {
       const user2Data = { theme: 'dark', notificationsEnabled: false };
 
       const user2Response = await request(app.getHttpServer())
-        .put('/user-preferences')
+        .put('/user/preferences')
         .set('Authorization', `Bearer ${user2Token}`)
         .send(user2Data)
         .expect(200);


### PR DESCRIPTION
# Pull Request

## Description
User preferences system needs to be Implemented to allow users customize their mood-content preferences, including preferred content types, mood intensity levels, and personal mood mappings.

## Related Issue

Fixes #69 

## Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation updates
- [ ] style: Code style/formatting changes
- [ ] refactor: Code refactoring
- [ ] perf: Performance improvements
- [ ] test: Test additions/updates
- [ ] chore: Build process or tooling changes
- [ ] ci: CI configuration changes
- [ ] other: <!-- describe -->

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests

## Test Evidence
![mood-test](https://github.com/user-attachments/assets/fc830bee-d9bb-4ed1-bd0c-e4b2188f75a3)

## Documentation Screenshots (if applicable)
![mood-test docs](https://github.com/user-attachments/assets/5c020733-0a84-440b-a359-1d7b39b628c9)

## Checklist

- [x] My code follows the project's coding style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have included a screenshot showing all tests passing
- [x] I have included documentation screenshots (if applicable)
